### PR TITLE
Use more friendly language when no commits found

### DIFF
--- a/git-standup
+++ b/git-standup
@@ -110,9 +110,9 @@ function runStandup() {
     elif [[ -z $option_s ]] ; then  ## Show the no activity message only if the `s` flag is not there
       echo "${BOLD}${UNDERLINE}${YELLOW}$CUR_DIR${NORMAL}"
       if [[ ${AUTHOR} = '.*' ]] ; then
-        echo "${YELLOW}Seems like no one did anything!${NORMAL}"
+        echo "${YELLOW}No commits found during this period.${NORMAL}"
       else
-        echo "${YELLOW}Seems like $AUTHOR did nothing!${NORMAL}"
+        echo "${YELLOW}No commits from $AUTHOR during this period.${NORMAL}"
       fi
     fi
   fi


### PR DESCRIPTION
This PR softens the language used when no commits are found. 

### Background

I just installed git-standup, and it's awesome! I have a lot of projects that I work on, but I tend to focus on just a few. When I ran `git standup` today, I saw my commits from yesterday, but I also saw this for the projects I didn't touch:

<img width="355" alt="git-standup" src="https://user-images.githubusercontent.com/1627089/53968451-afdc7200-40bc-11e9-84c8-f86c80eeb125.png">

It didn't make me feel great about myself. I suspect that using this everyday and seeing a bunch of messages saying "Seems like Steven Hicks did nothing!" would wear on me. A message like "No commits from Steven Hicks during this period" carries less judgement.
